### PR TITLE
Fix months.june casing

### DIFF
--- a/pr.json
+++ b/pr.json
@@ -250,7 +250,7 @@
     "march": "Março",
     "april": "Abril",
     "may": "Maio",
-    "june": "junho",
+    "june": "Junho",
     "july": "Julho",
     "august": "Agosto",
     "september": "Setembro",


### PR DESCRIPTION
months.june value is all lowercase. Fixes to uppercase the first letter.