### PR TITLE
Update de.json

### DIFF
--- a/de.json
+++ b/de.json
@@ -245,7 +245,7 @@
     "q4": "4. Quartal"
   },
   "months": {
-    "january": "Jänner",
+    "january": "Januar",
     "february": "Februar",
     "march": "März",
     "april": "April",
@@ -273,7 +273,7 @@
     "december": "Dez"
   },
   "weekdays": {
-    "first": "sonntag",
+    "first": "Sonntag",
     "second": "Montag",
     "third": "Dienstag",
     "fourth": "Mittwoch",


### PR DESCRIPTION
"Jänner" is Austrian German (de_AT), in Germany German (de_DE) it should be "Januar". Ported from https://github.com/flexmonster/pivot-localizations/commit/6c8c8e64dddcd78d55fcb15b9d4b9cb2d849d005

Weekdays are capicalized, but Sunday wasn't. I submitted this to Flexmonster as well: https://github.com/flexmonster/pivot-localizations/pull/10